### PR TITLE
Add templates for spack and reframe

### DIFF
--- a/reframe/package-name/package-name.py
+++ b/reframe/package-name/package-name.py
@@ -1,0 +1,17 @@
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+@rfm.simple_test
+class HelloTest(rfm.RegressionTest):
+
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+
+    @sanity_function
+    def foo(self):
+        return true
+
+    @performance_function
+    def bar(self):
+        return 1.0
+        

--- a/spack/packages/package-name/package.py
+++ b/spack/packages/package-name/package.py
@@ -1,0 +1,12 @@
+from spack.package import *
+
+class Example(MakefilePackage):
+    
+    homepage = "https://github.com/sa2c/sombrero"
+    url = "https://github.com/sa2c/sombrero/archive/refs/tags/1.0.tar.gz"
+
+    version(
+        "2021-08-16", sha256="f62aa1934fef6a025449a9e037345043072be6198f92087853c58c67f1342f73"
+    )
+
+    depends_on("mpi")

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: ukri-bench


### PR DESCRIPTION
Thanks for getting this started Andy. I had a go at adding some structure for the spack and reframe files in the repo. I think the idea was that the benchmark repo should have
- A spack repo
- A spack recipe (if it's not in upstream spack yet)
- A reframe test